### PR TITLE
Implement fix for time

### DIFF
--- a/script.js
+++ b/script.js
@@ -9,9 +9,12 @@ function updateTime() {
   let midday = "am";
 
   // if it's after 12pm, change midday variable to pm and substract 12 from hour
-  if (h > 12) {
-    h -= 12;
-    midday = "pm"
+  //Fix for 12pm and 12am -> was 12am and 0am before.
+  if (h >= 12) {
+    h = h === 12 ? h : h - 12;
+    midday = "pm";
+  } else if (h === 0) {
+    h = 12;
   }
 
   // string containing the hour and am/pm


### PR DESCRIPTION
Quick fix for correctly displaying the time.
12PM was "12AM" before and 12AM was displayed as "0AM"